### PR TITLE
support playback looping

### DIFF
--- a/cmd/replay/replay.go
+++ b/cmd/replay/replay.go
@@ -11,7 +11,7 @@ import (
 // go run cmd/replay/replay.go /home/ryan/Downloads/influx-sample-data.log "ws://localhost:3000/api/live/push/telegraf?gf_live_frame_format=labels_column" "eyJrIjoicExKYjlEN29yQmlrMEg4YmtodlRFSjN6R0FOUjRLMEQiLCJuIjoicHVibGlzaCIsImlkIjoxfQ=="
 
 // to loop forever:
-// go run cmd/replay/replay.go /home/ryan/Downloads/influx-sample-data.log "ws://localhost:3000/api/live/push/telegraf?gf_live_frame_format=labels_column" "eyJrIjoicExKYjlEN29yQmlrMEg4YmtodlRFSjN6R0FOUjRLMEQiLCJuIjoicHVibGlzaCIsImlkIjoxfQ==" loop
+// go run cmd/replay/replay.go /home/ryan/Downloads/influx-sample-data.log "ws://localhost:3000/api/live/push/telegraf" "eyJrIjoicExKYjlEN29yQmlrMEg4YmtodlRFSjN6R0FOUjRLMEQiLCJuIjoicHVibGlzaCIsImlkIjoxfQ==" loop
 
 func main() {
 	if len(os.Args) < 3 {

--- a/cmd/replay/replay.go
+++ b/cmd/replay/replay.go
@@ -47,7 +47,9 @@ func main() {
 	for {
 		count := replay.ReplayInfluxLog(fpath, interval, ws.Write)
 		fmt.Printf("wrote: %d lines.\n", count)
-		if loop == "" {
+		if loop == "loop" {
+			continue
+		} else {
 			break
 		}
 	}

--- a/cmd/replay/replay.go
+++ b/cmd/replay/replay.go
@@ -10,6 +10,9 @@ import (
 
 // go run cmd/replay/replay.go /home/ryan/Downloads/influx-sample-data.log "ws://localhost:3000/api/live/push/telegraf?gf_live_frame_format=labels_column" "eyJrIjoicExKYjlEN29yQmlrMEg4YmtodlRFSjN6R0FOUjRLMEQiLCJuIjoicHVibGlzaCIsImlkIjoxfQ=="
 
+// to loop forever:
+// go run cmd/replay/replay.go /home/ryan/Downloads/influx-sample-data.log "ws://localhost:3000/api/live/push/telegraf?gf_live_frame_format=labels_column" "eyJrIjoicExKYjlEN29yQmlrMEg4YmtodlRFSjN6R0FOUjRLMEQiLCJuIjoicHVibGlzaCIsImlkIjoxfQ==" loop
+
 func main() {
 	if len(os.Args) < 3 {
 		fmt.Printf("Expected:\n")
@@ -19,6 +22,10 @@ func main() {
 
 	fpath := os.Args[1]
 	url := os.Args[2]
+	loop := ""
+	if len(os.Args) > 4 {
+		loop = os.Args[4]
+	}
 
 	// fpath := "/home/ryan/Downloads/influx-sample-data.log"
 	// url := "ws://localhost:3000/api/live/push/telegraf?gf_live_frame_format=labels_column"
@@ -37,6 +44,11 @@ func main() {
 	}
 
 	interval := 50 * time.Millisecond
-	count := replay.ReplayInfluxLog(fpath, interval, ws.Write)
-	fmt.Printf("wrote: %d lines.\n", count)
+	for {
+		count := replay.ReplayInfluxLog(fpath, interval, ws.Write)
+		fmt.Printf("wrote: %d lines.\n", count)
+		if loop == "" {
+			break
+		}
+	}
 }

--- a/cmd/replay/replay.go
+++ b/cmd/replay/replay.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/signal-generator-datasource/pkg/replay"
 )
 
-// go run cmd/replay/replay.go /home/ryan/Downloads/influx-sample-data.log "ws://localhost:3000/api/live/push/telegraf?gf_live_frame_format=labels_column" "eyJrIjoicExKYjlEN29yQmlrMEg4YmtodlRFSjN6R0FOUjRLMEQiLCJuIjoicHVibGlzaCIsImlkIjoxfQ=="
+// go run cmd/replay/replay.go /home/ryan/Downloads/influx-sample-data.log "ws://localhost:3000/api/live/push/telegraf" "eyJrIjoicExKYjlEN29yQmlrMEg4YmtodlRFSjN6R0FOUjRLMEQiLCJuIjoicHVibGlzaCIsImlkIjoxfQ=="
 
 // to loop forever:
 // go run cmd/replay/replay.go /home/ryan/Downloads/influx-sample-data.log "ws://localhost:3000/api/live/push/telegraf" "eyJrIjoicExKYjlEN29yQmlrMEg4YmtodlRFSjN6R0FOUjRLMEQiLCJuIjoicHVibGlzaCIsImlkIjoxfQ==" loop

--- a/pkg/replay/replay.go
+++ b/pkg/replay/replay.go
@@ -63,9 +63,9 @@ func ReplayInfluxLog(fpath string, interval time.Duration, player Replayer) int 
 
 		delta := timestamp - lastTime
 		if delta > 0 && len(batch) > 0 {
-			shitedTime := (timestamp + offsetTime) * timestampScale
+			shiftedTime := (timestamp + offsetTime) * timestampScale
 
-			delta := shitedTime - time.Now().UnixNano()
+			delta := shiftedTime - time.Now().UnixNano()
 			if delta > 0 {
 				sleepTime := time.Nanosecond * time.Duration(delta)
 				if sleepTime < interval {


### PR DESCRIPTION
this includes a flag for looping the playback forever if needed:

`go run cmd/replay/replay.go /home/ryan/Downloads/influx-sample-data.log "ws://localhost:3000/api/live/push/telegraf?gf_live_frame_format=labels_column" "eyJrIjoicExKYjlEN29yQmlrMEg4YmtodlRFSjN6R0FOUjRLMEQiLCJuIjoicHVibGlzaCIsImlkIjoxfQ==" loop`

note the `loop' arg